### PR TITLE
Fix generating openapi spec using make:tchi command

### DIFF
--- a/src/Console/MakeTchiCommand.php
+++ b/src/Console/MakeTchiCommand.php
@@ -234,8 +234,10 @@ class MakeTchiCommand extends GeneratorCommand
         $json = Typer::assertArray(\json_decode($openApi, true));
 
         $json['tags'] = \array_merge(Typer::assertArray($json['tags']), [
-            'name' => $table,
-            'description' => $modelName,
+            [
+                'name' => $table,
+                'description' => $modelName,
+            ],
         ]);
 
         $json['paths']["/{$table}/index"] = [


### PR DESCRIPTION
This PR fixes the make:tchi command bug

Steps to reproduce the bug:

run 
`php artisan make:tchi Model`

check the `openapi_v1.json` file
